### PR TITLE
aviutl_exedit_sdkをGitサブモジュールとして追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-
-    - name: Clone aviutl_exedit_sdk
-      run: git clone https://github.com/ePi5131/aviutl_exedit_sdk.git vendor/aviutl_exedit_sdk
+      with:
+        submodules: recursive
 
     - name: Set up MSVC
       uses: microsoft/setup-msbuild@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 [Bb]uild/
-[Vv]endor/
 *.auf
 
 # User-specific files

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/aviutl_exedit_sdk"]
+	path = vendor/aviutl_exedit_sdk
+	url = https://github.com/ePi5131/aviutl_exedit_sdk.git


### PR DESCRIPTION
## 変更内容
- `aviutl_exedit_sdk`外部ライブラリを`vendor`ディレクトリからGitサブモジュールとしてプロジェクトに追加しました。これにより、このライブラリのバージョン管理が容易になります。

## 背景
以前は`aviutl_exedit_sdk`を`vendor`ディレクトリ内に直接配置し、`.gitignore`で無視していました。しかし、このライブラリの更新をより簡単に追跡し、プロジェクトの他の開発者との互換性を保つために、Gitサブモジュールとして管理することにしました。

## テスト
- [x] `aviutl_exedit_sdk`のサブモジュールが正しくチェックアウトされ、ビルドが成功することを確認しました。
- [x] 既存の機能がこの変更によって影響を受けないことを確認しました。

## 注意事項
この変更を取り込むには、既存のリポジトリで次のコマンドを実行して、サブモジュールを初期化および更新する必要があります:
```
git submodule update --init --recursive
```