### PR TITLE
CLI11ライブラリを使用したコマンドライン引数の処理の改善

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,9 @@ indent_size = 4
 
 [*.{c,cpp,h,hpp}]
 charset = cp932
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Setup Environment Variable
+      shell: pwsh
+      run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
+
     - name: Checkout Repository
       uses: actions/checkout@v4
       with:
@@ -23,10 +27,10 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Configure CMake
-      run: cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release -A Win32
+      run: cmake --preset default
 
     - name: Build
-      run: cmake --build build --config Release
+      run: cmake --build build --preset release
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 [Bb]uild/
 *.auf
+CMakeUserPresets.json
 
 # User-specific files
 *.rsuser

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.21)
+
 project(aviutl_plugin_dumper)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(CLI11 CONFIG REQUIRED)
 
 add_executable(aviutl_plugin_dumper
     src/aviutl_plugin_dumper.cpp
@@ -12,4 +15,7 @@ add_executable(aviutl_plugin_dumper
 target_include_directories(aviutl_plugin_dumper PRIVATE
     vendor/aviutl_exedit_sdk
 )
-target_link_libraries(aviutl_plugin_dumper bcrypt)
+target_link_libraries(aviutl_plugin_dumper
+    CLI11::CLI11
+    bcrypt
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(aviutl_plugin_dumper)
+project(aviutl_plugin_dumper
+    VERSION 0.1.0
+)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -9,6 +11,7 @@ find_package(CLI11 CONFIG REQUIRED)
 
 add_executable(aviutl_plugin_dumper
     src/aviutl_plugin_dumper.cpp
+    src/version.hpp
     src/Sha256Hasher.hpp
     src/Sha256Hasher.cpp
 )
@@ -18,4 +21,8 @@ target_include_directories(aviutl_plugin_dumper PRIVATE
 target_link_libraries(aviutl_plugin_dumper
     CLI11::CLI11
     bcrypt
+)
+target_compile_definitions(aviutl_plugin_dumper
+    PRIVATE
+        APP_VERSION="${PROJECT_VERSION}"
 )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "default",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Visual Studio 17 2022",
+      "architecture": "Win32",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x86-windows"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "default",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "default",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/src/aviutl_plugin_dumper.cpp
+++ b/src/aviutl_plugin_dumper.cpp
@@ -10,6 +10,7 @@
 #include <CLI/CLI.hpp>
 
 #include "Sha256Hasher.hpp"
+#include "version.hpp"
 
 namespace fs = std::filesystem;
 
@@ -112,6 +113,8 @@ int main(int argc, char* argv[]) {
     std::vector<std::string> inputs;
     app.add_option("input", inputs, "plugin file path")
         ->check(CLI::ExistingFile);
+
+    app.set_version_flag("-v,--version", APP_VERSION, "Print version");
 
     CLI11_PARSE(app, argc, argv);
 

--- a/src/aviutl_plugin_dumper.cpp
+++ b/src/aviutl_plugin_dumper.cpp
@@ -3,8 +3,11 @@
 #include <iostream>
 #include <filesystem>
 #include <format>
+#include <vector>
+#include <string>
 
 #include <aviutl.hpp>
+#include <CLI/CLI.hpp>
 
 #include "Sha256Hasher.hpp"
 
@@ -104,12 +107,16 @@ void dump(const char* path) {
 }
 
 int main(int argc, char* argv[]) {
-    if (argc == 1) {
-        return 1;
-    }
+    CLI::App app{"Dump AviUtl plugin info."};
 
-    for (int i = 1; i < argc; i++) {
-        dump(argv[i]);
+    std::vector<std::string> inputs;
+    app.add_option("input", inputs, "plugin file path")
+        ->check(CLI::ExistingFile);
+
+    CLI11_PARSE(app, argc, argv);
+
+    for (const auto& input : inputs) {
+        dump(input.c_str());
     }
 
     return 0;

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef APP_VERSION
+#define APP_VERSION "0.0.0"
+#endif

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "ba2298b26ce17b5248685d30b359185485413674",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "aviutl-plugin-dumper",
+  "dependencies": [
+    "cli11"
+  ]
+}


### PR DESCRIPTION
## 概要
このプルリクエストでは、CLIツールのコマンドライン引数の処理を改善するために、CLI11ライブラリをプロジェクトに導入しました。また、バージョン情報を出力する機能も追加し、GitHub ActionsのワークフローをvcpkgとCMakePresets.jsonを使用するように更新しました。

## 変更点
- vcpkgを利用してプロジェクトの依存関係にCLI11を追加しました。
- コマンドライン引数のパース処理をCLI11を使用するようにリファクタリングしました。
- `-v`または`--version`フラグを使用した際にバージョン情報を出力する機能を実装しました。
- GitHub Actionsのワークフローを更新し、vcpkgとCMakePresets.jsonを参照するようにしました。

## 目的
- コマンドライン引数の処理をより効率的かつ安全に行うために、標準化されたライブラリを導入しました。
- ユーザーがCLIツールのバージョン情報を簡単に取得できるようにし、トラブルシューティングを容易にします。
- ビルドプロセスの一貫性と再現性を向上させるために、GitHub Actionsワークフローを最新のベストプラクティスに合わせて更新しました。

## 検証
- ローカル環境およびCI環境でビルドが正常に完了することを確認しました。
- 新しいコマンドラインオプションが期待通りに機能することを手動でテストしました。